### PR TITLE
onError and onTelemetry handlers

### DIFF
--- a/e2e/core/mocks/transport.ts
+++ b/e2e/core/mocks/transport.ts
@@ -23,4 +23,12 @@ export class MockTransport implements Transport {
     this.sentRequests = [];
     this.shouldFail = false;
   }
-}
+
+  getRequestData(index: number) : any {
+    if (!this.sentRequests[index]) {
+      return undefined;
+    }
+
+    return JSON.parse(this.sentRequests[index].data as string);
+  }
+ }

--- a/e2e/core/node-integration.test.ts
+++ b/e2e/core/node-integration.test.ts
@@ -1,104 +1,134 @@
 import { TrackJS, timestamp, userAgent } from "@trackjs/core";
-import { test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach, vi } from "vitest";
 import { MockTransport } from "./mocks/transport";
 import type { NetworkTelemetry, Transport, TransportRequest, TransportResponse } from "@trackjs/core";
 
+let transport: MockTransport;
+
 beforeEach(() => {
   TrackJS.destroy();
+  transport = new MockTransport();
 });
 
-test('TrackJS.install({...}) with minimum options', () => {
-  TrackJS.initialize({
-    token: "test-token",
-  });
-  expect(TrackJS.isInitialized()).toBe(true);
-});
+describe("TrackJS.install({...}", () => {
 
-test('TrackJS.track() can track errors after install', async () => {
-  const transport = new MockTransport();
-
-  TrackJS.initialize({
-    token: 'test-token',
-    transport
+  test('with minimum options', () => {
+    TrackJS.initialize({
+      token: "test-token",
+    });
+    expect(TrackJS.isInitialized()).toBe(true);
   });
 
-  // Track different error types
-  await TrackJS.track('String error');
-  await TrackJS.track(new Error('Error'));
-  await TrackJS.track({ custom: 'object' });
+  test('with initial metadata', async () => {
+    TrackJS.initialize({
+      token: "test-token",
+      metadata: {
+        "foo": "bar"
+      },
+      transport
+    });
 
-  // Verify requests were sent
-  expect(transport.sentRequests).toHaveLength(3);
-
-  // Verify the structure of a request
-  const firstRequest = transport.sentRequests[0] as TransportRequest;
-  expect(firstRequest.method).toBe('POST');
-  expect(firstRequest.url).toBe('https://capture.trackjs.com/capture/node?token=test-token&v=core-0.0.0');
-
-  expect(JSON.parse(firstRequest.data as string)).toMatchObject({
-    message: '"String error"',
-    stack: expect.any(String)
-  });
-  expect(JSON.parse(transport.sentRequests[1]?.data as string)).toMatchObject({
-    message: 'Error',
-    stack: expect.any(String)
-  });
-  expect(JSON.parse(transport.sentRequests[2]?.data as string)).toMatchObject({
-    message: '{"custom":"object"}',
-    stack: expect.any(String)
-  });
-});
-
-test('TrackJS.track() with environment', async () => {
-  const transport = new MockTransport();
-
-  TrackJS.initialize({
-    token: 'test token',
-    transport,
-    dependencies: {
-      "foo": "1.2.3"
-    },
-    originalUrl: "original-url",
-    referrerUrl: "referrer-url",
-    userAgent: userAgent("Node", "12.1", "windows", "x64", "11.2"),
+    await TrackJS.track("test");
+    expect(transport.sentRequests).toHaveLength(1);
+    expect(transport.getRequestData(0)).toMatchObject({
+      customer: expect.objectContaining({
+        token: "test-token"
+      }),
+      metadata: [
+        { key: "foo", value: "bar" }
+      ]
+    })
   });
 
-  await TrackJS.track(new Error('Oops'));
+  test('with onError Handler', async () => {
+    const handler = vi.fn().mockImplementation(() => false);
 
-  expect(transport.sentRequests).toHaveLength(1);
-  expect(JSON.parse(transport.sentRequests[0]?.data as string)).toMatchObject({
-    environment: expect.objectContaining({
-      originalUrl: "original-url",
-      referrer: "referrer-url",
+    TrackJS.initialize({
+      token: "test-token",
+      transport,
+      onError: handler
+    });
+
+    await TrackJS.track("test222");
+
+    expect(handler).toHaveBeenCalled();
+    console.log(transport.sentRequests);
+    expect(transport.sentRequests).toHaveLength(0);
+  });
+
+  test('with environment info', async () => {
+    TrackJS.initialize({
+      token: 'test token',
+      transport,
       dependencies: {
         "foo": "1.2.3"
       },
-      userAgent: "Node/12.1 (windows x64 11.2)"
-    })
+      originalUrl: "original-url",
+      referrerUrl: "referrer-url",
+      userAgent: userAgent("Node", "12.1", "windows", "x64", "11.2"),
+    });
+
+    await TrackJS.track(new Error('test'));
+
+    expect(transport.sentRequests).toHaveLength(1);
+    expect(JSON.parse(transport.sentRequests[0]?.data as string)).toMatchObject({
+      environment: expect.objectContaining({
+        originalUrl: "original-url",
+        referrer: "referrer-url",
+        dependencies: {
+          "foo": "1.2.3"
+        },
+        userAgent: "Node/12.1 (windows x64 11.2)"
+      }),
+    });
+  })
+
+});
+
+describe("TrackJS.track(...)", () => {
+
+  test('can track errors after install', async () => {
+    TrackJS.initialize({
+      token: 'test-token',
+      transport
+    });
+
+    await TrackJS.track('String error');
+    await TrackJS.track(new Error('Error'));
+    await TrackJS.track({ custom: 'object' });
+
+    expect(transport.sentRequests).toHaveLength(3);
+    expect(transport.getRequestData(0)).toMatchObject({
+      message: '"String error"',
+      stack: expect.any(String)
+    });
+    expect(transport.getRequestData(1)).toMatchObject({
+      message: 'Error',
+      stack: expect.any(String)
+    });
+    expect(transport.getRequestData(2)).toMatchObject({
+      message: '{"custom":"object"}',
+      stack: expect.any(String)
+    });
   });
-})
 
-test('TrackJS.track() with custom metadata', async () => {
-  const transport = new MockTransport();
+  test('TrackJS.track() with custom metadata', async () => {
+    TrackJS.initialize({
+      token: 'test token',
+      transport
+    });
 
-  TrackJS.initialize({
-    token: 'test token',
-    transport,
-    metadata: {
-      "foo": "bar"
-    }
-  });
+    await TrackJS.track(new Error('Oops'), { metadata: { "bar": "baz" }});
 
-  await TrackJS.track(new Error('Oops'), { metadata: { "bar": "baz" }});
+    expect(transport.sentRequests).toHaveLength(1);
+    expect(transport.getRequestData(0)).toMatchObject({
+      metadata: [
+        { key: "bar", value: "baz" }
+      ]
+    });
+  })
 
-  expect(transport.sentRequests).toHaveLength(1);
-  expect(JSON.parse(transport.sentRequests[0]?.data as string)).toMatchObject({
-    metadata: [
-      { key: "foo", value: "bar" },
-      { key: "bar", value: "baz" }
-    ]
-  });
-})
+});
 
 test('TrackJS.addTelemetry(...) sends telemetry', async () => {
   const transport = new MockTransport();
@@ -151,4 +181,3 @@ test('TrackJS.addTelemetry(...) sends telemetry', async () => {
     ]
   });
 });
-

--- a/e2e/core/package.json
+++ b/e2e/core/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest"
+    "dev": "vitest"
   },
   "dependencies": {
     "@trackjs/core": "file:../../packages/core"

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3,6 +3,8 @@ import { TelemetryLog } from "./telemetryLog";
 import { timestamp, serialize, isError } from "./utils";
 import type {
   CapturePayload,
+  ErrorHandler,
+  TelemetryHandler,
   Options,
   Telemetry,
   TelemetryType,
@@ -13,11 +15,15 @@ export class Client {
   private options: Options;
   private metadata: Metadata;
   private telemetry: TelemetryLog;
+  private errorHandlers: Set<ErrorHandler>;
+  private telemetryHandlers: Set<TelemetryHandler>;
 
   constructor(options: Options) {
     this.options = options;
     this.metadata = new Metadata(this.options.metadata);
     this.telemetry = new TelemetryLog();
+    this.errorHandlers = new Set(!!options.onError ? [options.onError] : undefined);
+    this.telemetryHandlers = new Set();
   }
 
   public addMetadata(metadata: Record<string, string>): void {
@@ -29,10 +35,25 @@ export class Client {
   }
 
   public addTelemetry(type: TelemetryType, telemetry: Telemetry): void {
-    this.telemetry.add(type, telemetry);
+    let prevented = false;
+    for(const handler of this.telemetryHandlers) {
+      prevented = prevented || !handler(type, telemetry);
+    }
+
+    if (!prevented) {
+      this.telemetry.add(type, telemetry);
+    }
   }
 
-  public async track(error: Error | object | string, options?: Partial<TrackOptions>): Promise<void> {
+  public onError(handler: ErrorHandler) : void {
+    this.errorHandlers.add(handler);
+  }
+
+  public onTelemetry(handler: TelemetryHandler) : void {
+    this.telemetryHandlers.add(handler);
+  }
+
+  public async track(error: Error | object | string, options?: Partial<TrackOptions>): Promise<boolean> {
     const safeOptions: TrackOptions = {
       entry: "direct",
       metadata: {},
@@ -40,10 +61,18 @@ export class Client {
     };
 
     const safeError = isError(error) ? error as Error : new Error(serialize(error))
-
     const payload = this._createPayload(safeError, safeOptions);
 
-    await this._send(payload);
+    let prevented = false;
+    for(const handler of this.errorHandlers) {
+      prevented = prevented || !handler(payload);
+    }
+
+    if (!prevented) {
+      await this._send(payload);
+    }
+
+    return !prevented;
   }
 
   /**

--- a/packages/core/src/trackjs.ts
+++ b/packages/core/src/trackjs.ts
@@ -3,7 +3,6 @@ import { Client } from "./client";
 import { uuid, configureSerializer } from "./utils";
 
 import type {
-  CapturePayload,
   Options,
   TrackOptions,
   ConsoleTelemetry,
@@ -11,7 +10,9 @@ import type {
   NetworkTelemetry,
   Telemetry,
   TelemetryType,
-  VisitorTelemetry
+  VisitorTelemetry,
+  ErrorHandler,
+  TelemetryHandler
 } from "./types";
 
 let config: Options | null = null;
@@ -25,7 +26,6 @@ const defaultOptions: Options = {
   correlationId: uuid(),
   errorURL: "https://capture.trackjs.com/capture/node",
   metadata: {},
-  onError: () => true,
   originalUrl: "",
   referrerUrl: "",
   serializer: [],
@@ -172,6 +172,49 @@ export function addTelemetry(type: TelemetryType, telemetry: Telemetry): void {
 }
 
 /**
+ * Adds a custom event handler for errors. Error Event handlers are passed a
+ * reference to the {@link CapturePayload} to be inspected or modified. Returning
+ * `false` will prevent the error from being sent.
+ *
+ * @param handler - {@link ErrorHandler} function to process or prevent the error.
+ * @example
+ * ```
+ * TrackJS.onError((payload) => {
+ *   return payload.entry === "network"; // prevent network errors.
+ * });
+ * ```
+ */
+export function onError(handler: ErrorHandler) : void {
+  _checkInitialized();
+  _checkRequired("Handler", handler);
+
+  return client!.onError(handler);
+}
+
+/**
+ * Adds a custom event handler for telemetry. Telemetry Event handlers are passed a
+ * reference to the type and {@link Telemetry} to be inspected or modified. Returning
+ * `false` will prevent the telemetry from being recorded.
+ *
+ * @param handler - {@link TelemetryHandler} function to process or prevent the telemetry.
+ * @example
+ * ```
+ * TrackJS.onTelemetry((type, telemetry) => {
+ *   if (type === "net") {
+ *     telemetry.url = telemetry.url.replace("stage.", ""); // remove staging subdomain
+ *   }
+ *   return true;
+ * });
+ * ```
+ */
+export function onTelemetry(handler: TelemetryHandler) : void {
+  _checkInitialized();
+  _checkRequired("Handler", handler);
+
+  return client!.onTelemetry(handler);
+}
+
+/**
  * Track and error or error-like object to the TrackJS error monitoring service.
  *
  * @param error - Error or error-like object. If a non-error is provided, it will
@@ -191,21 +234,12 @@ export async function track(error: Error|object|string, options?: Partial<TrackO
   _checkInitialized();
   _checkRequired("Error", error);
 
-  await client!.track(error, options);
-  return true;
+  return await client!.track(error, options);
 }
 
 export function usage(): void {
   throw new Error("not implemented");
 }
-
-export function onError(callback: (payload: CapturePayload) => boolean) : void {
-  throw new Error("not implemented");
-}
-
-// export function onTelemetry(callback: (type: TelemetryType, telemetry: ConsoleTelemetry|NavigationTelemetry|NetworkTelemetry|VisitorTelemetry) => boolean) : void {
-//   throw new Error("not implemented");
-// }
 
 /**
  * Removes the TrackJS initialization and options.

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -1,6 +1,7 @@
-import { SerializeHandler } from "../utils";
+import type { SerializeHandler } from "../utils";
 import type { HTTPMethods } from "./common";
 import type { CapturePayload } from "./payload";
+import type { Telemetry, TelemetryType } from "./telemetry";
 
 /**
  * Transport interface for sending data over the network. Provide a transport that
@@ -23,6 +24,27 @@ export interface TransportRequest {
 export interface TransportResponse {
   status: number;
 }
+
+/**
+ * Error event handler function for processing or preventing an error event that
+ * is about to be tracked by the agent.
+ *
+ * @param payload - Reference to the full error capture payload that will be sent.
+ * You can modify the contents of the payload to add or remove data.
+ * @returns False if the error should be prevented from sending.
+ */
+export type ErrorHandler = (payload: CapturePayload) => boolean;
+
+/**
+ * Telemetry event handler function for processing or preventing telemetry
+ * events from being added to the log.
+ *
+ * @param type - Type of Telemetry entry to be added
+ * @param telemetry - Reference to the telemetry object to be added. You can
+ * modify the contents of the telemetry to add or remove data.
+ * @return False if the telemetry should be prevented.
+ */
+export type TelemetryHandler = (type: TelemetryType, telemetry: Telemetry) => boolean;
 
 export interface TrackOptions {
   /**
@@ -92,11 +114,9 @@ export interface Options {
   /**
    * Custom handler to manipulate or suppress errors captured by the agent.
    *
-   * @param payload error payload to be sent to TrackJS.
-   * @returns false will suppress the error from being sent.
-   * @default (payload) => true
+   * @see {@link ErrorHandler}
    */
-  onError: (payload: CapturePayload) => boolean;
+  onError?: ErrorHandler
 
   /**
    * When environment has a user interface, the URI location where the application
@@ -147,7 +167,6 @@ export interface Options {
    * operating system, arch, and version. For non-browser environments, this can
    * be constructed with the userAgent() util function.
    *
-   * @see {@link userAgent}
    * @defaults ""
    */
   userAgent: string

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -3,12 +3,13 @@ import { Client } from "../src/client";
 import { timestamp } from "../src/utils";
 import { MockTransport } from "./mocks/transport";
 import type { Options } from "../src/types";
+import { ConsoleTelemetry } from "../dist/types";
 
-let mockTransport: MockTransport;
+let transport: MockTransport;
 let defaultOptions: Options;
 
 beforeEach(() => {
-  mockTransport = new MockTransport();
+  transport = new MockTransport();
   defaultOptions = {
     agent: "test",
     agentVersion: "1.2.3",
@@ -25,13 +26,118 @@ beforeEach(() => {
     serializer: [],
     sessionId: 'test-session',
     token: 'test-token',
-    transport: mockTransport,
+    transport,
     userAgent: "test-agent",
     userId: 'test-user',
     version: '0.0.0',
     viewportHeight: 100,
     viewportWidth: 200
   };
+});
+
+describe("onError()", () => {
+
+  test("handler can change payloads", async () => {
+    const client = new Client(defaultOptions);
+    client.onError((payload) => {
+      payload.message = "changed message";
+      return true;
+    });
+
+    expect(await client.track(new Error("original message"))).toBe(true);
+
+    expect(transport.sentRequests.length).toBe(1);
+    expect(JSON.parse(transport.sentRequests[0]!.data as string)).toMatchObject({
+      message: "changed message"
+    });
+  });
+
+  test("handler can prevent payloads", async () => {
+    const client = new Client(defaultOptions);
+    client.onError((payload) => {
+      return false;
+    });
+
+    expect(await client.track(new Error("original message"))).toBe(false);
+
+    expect(transport.sentRequests.length).toBe(0);
+  });
+
+  test("handlers are not called after prevented", async () => {
+    const client = new Client(defaultOptions);
+    const handler1 = vi.fn().mockImplementation(() => false);
+    client.onError(handler1);
+    const handler2 = vi.fn().mockImplementation(() => true);
+    client.onError(handler2);
+
+    expect(await client.track(new Error("original message"))).toBe(false);
+
+    expect(handler1).toHaveBeenCalled();
+    expect(handler2).not.toHaveBeenCalled();
+  });
+
+});
+
+describe("onTelemetry()", () => {
+
+  test("handler can change telemetry", () => {
+    const client = new Client(defaultOptions);
+    client.onTelemetry((type, telemetry) => {
+      if (type === "con") {
+        (telemetry as ConsoleTelemetry).message = "changed message";
+      }
+      return true;
+    });
+    client.addTelemetry("con", {
+      timestamp: timestamp(),
+      severity: "log",
+      message: "original message"
+    });
+    const payload = client._createPayload(new Error("test"), { entry: "direct", metadata: {} });
+    expect(payload).toMatchObject({
+      console: [
+        {
+          timestamp: expect.any(String),
+          severity: "log",
+          message: "changed message"
+        }
+      ]
+    })
+  });
+
+  test("handler can prevent telemetry", () => {
+    const client = new Client(defaultOptions);
+    client.onTelemetry((type, telemetry) => {
+      return false;
+    });
+    client.addTelemetry("con", {
+      timestamp: timestamp(),
+      severity: "log",
+      message: "original message"
+    });
+    const payload = client._createPayload(new Error("test"), { entry: "direct", metadata: {} });
+    expect(payload).toMatchObject({
+      console: []
+    })
+  });
+
+  test("handlers are not called after prevented", () => {
+    const client = new Client(defaultOptions);
+    const handler1 = vi.fn().mockImplementation(() => false);
+    client.onTelemetry(handler1);
+    const handler2 = vi.fn().mockImplementation(() => true);
+    client.onTelemetry(handler2);
+
+    client.addTelemetry("con", {
+      timestamp: timestamp(),
+      severity: "log",
+      message: "original message"
+    });
+
+    expect(handler1).toHaveBeenCalled();
+    expect(handler2).not.toHaveBeenCalled();
+  });
+
 });
 
 describe("_createPayload()", () => {
@@ -197,8 +303,8 @@ describe("_send()", () => {
 
     await client._send(payload);
 
-    expect(mockTransport.sentRequests).toHaveLength(1);
-    const request = mockTransport.sentRequests[0];
+    expect(transport.sentRequests).toHaveLength(1);
+    const request = transport.sentRequests[0];
 
     expect(request).toBeDefined();
     expect(request!.method).toBe("POST");
@@ -222,8 +328,8 @@ describe("track()", () => {
       metadata: { custom: "value" }
     });
 
-    expect(mockTransport.sentRequests).toHaveLength(1);
-    const request = mockTransport.sentRequests[0];
+    expect(transport.sentRequests).toHaveLength(1);
+    const request = transport.sentRequests[0];
     expect(request).toBeDefined();
     const sentData = JSON.parse(request!.data as string);
 
@@ -238,8 +344,8 @@ describe("track()", () => {
 
     await client.track({ custom: "object" });
 
-    expect(mockTransport.sentRequests).toHaveLength(1);
-    const request = mockTransport.sentRequests[0];
+    expect(transport.sentRequests).toHaveLength(1);
+    const request = transport.sentRequests[0];
     expect(request).toBeDefined();
     const sentData = JSON.parse(request!.data as string);
 
@@ -253,8 +359,8 @@ describe("track()", () => {
 
     await client.track(error);
 
-    expect(mockTransport.sentRequests).toHaveLength(1);
-    const request = mockTransport.sentRequests[0];
+    expect(transport.sentRequests).toHaveLength(1);
+    const request = transport.sentRequests[0];
     expect(request).toBeDefined();
     const sentData = JSON.parse(request!.data as string);
 


### PR DESCRIPTION
The agent now allows you to add handlers for errors or telemetry. This allows the user or wrapping agents to manipulate things to add more data or prevent something from being sent.

```javascript
TrackJS.onError((payload) => {
  return payload.entry !== "network"; // ignore all network errors
});
```

```javascript
TrackJS.onTelemetry((type, telemetry) => {
  if (type === "con") {
    telemetry.message = telemetry.message.replace(/thing-that-looks-secret/, "SECRET");
  }
  return true;
});
```

